### PR TITLE
Android formatting tweaks

### DIFF
--- a/lib/twine/formatters/apple.rb
+++ b/lib/twine/formatters/apple.rb
@@ -156,6 +156,10 @@ module Twine
         end
       end
 
+      def should_include_definition(definition, lang)
+        return super(definition, lang) && !definition.translation_for_lang(lang).include?("`")
+      end
+
       def format_sections(twine_file, lang)
         first_plural = true
         out_file = File.open(plural_output_file_for_lang(lang), "w")

--- a/lib/twine/twine_file.rb
+++ b/lib/twine/twine_file.rb
@@ -63,7 +63,7 @@ module Twine
 
     # Twine adds a copy of the dev language's translation if there is no definition provided for the language,
     # which is useful in the main Localizable.strings file because iOS doesn't auto use the Base language's
-    # value, but we don't want that behaviour in our plurals
+    # value, but we don't want that behaviour in our plurals OR our android files
     def translation_for_lang_or_nil(lang, dev_lang)
       translation = [lang].flatten.map { |l| @translations[l] }.first
 


### PR DESCRIPTION
This addresses two quirks of Android string resources:
1. Android allows extensive HTML-styling in string resources when annotated correctly in two formats:
   `<![CDATA[styled text]]>` and `<a href=“/item”><b>bold clickable text</b></a>`
2. Android doesn't need a translation string file to have all keys and will default to the base string file.

Now:
1.  Twine will surround text with `text` to show that it is to be left as is and outputted verbatim to whatever’s inside the double quotes. iOS strings do not support such extensive HTML-styling in their string resources so we do not include double quoted strings to be included in iOS string files.
2. Twine automatically inserts the base language’s definition into the foreign language, but we do not want this behaviour in Android because it will automatically pull from the base language’s value in code. This will also show up as red/missing translation in Android Studio’s translation editor, which will notify the developer that they are missing translations, instead of silently filling it in.
   This shouldn’t happen on iOS because without that replacement definition, the system will not automatically use the base language’s value and show the key instead, which is in snake case and is ugly.
